### PR TITLE
Adjusted arm tracking so it is no longer wonky before game starts

### DIFF
--- a/ExtremeRLGL/Assets/Resources/Player.prefab
+++ b/ExtremeRLGL/Assets/Resources/Player.prefab
@@ -1998,7 +1998,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4412153810533655661}
   m_LocalRotation: {x: 0.52362394, y: -0.5236234, z: 0.47520354, w: 0.47520334}
-  m_LocalPosition: {x: -0.526, y: 1.528, z: -0.174}
+  m_LocalPosition: {x: -0.526, y: 1.509, z: -0.26}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 4412153811564758208}
@@ -2028,7 +2028,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4412153811429843318}
   m_LocalRotation: {x: 0.51161337, y: 0.51161766, z: -0.48810655, w: 0.48810983}
-  m_LocalPosition: {x: 0.525, y: 1.517, z: -0.158}
+  m_LocalPosition: {x: 0.521, y: 1.521, z: -0.248}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 4412153810524200156}

--- a/ExtremeRLGL/Assets/Scripts/NetworkPlayer.cs
+++ b/ExtremeRLGL/Assets/Scripts/NetworkPlayer.cs
@@ -25,6 +25,7 @@ public class NetworkPlayer : MonoBehaviour
     private Transform leftHandRig;
     private Transform rightHandRig;
 
+    XROrigin rig;
     
 
     private PlayerInteraction playerInteraction;
@@ -38,7 +39,8 @@ public class NetworkPlayer : MonoBehaviour
         // we flag as don't destroy on load so that instance survives level synchronization, thus giving a seamless experience when levels load.
         DontDestroyOnLoad(this.gameObject);
 
-        XROrigin rig = FindObjectOfType<XROrigin>();
+        rig = FindObjectOfType<XROrigin>();
+        //rig.transform.position = gameObject.transform.position;
         headRig = rig.transform.Find("Camera Offset/Main Camera");
         leftHandRig = rig.transform.Find("Camera Offset/LeftHand Controller");
         rightHandRig = rig.transform.Find("Camera Offset/RightHand Controller");
@@ -65,14 +67,16 @@ public class NetworkPlayer : MonoBehaviour
             // current fix to setting up camera/controller on scene change is to just keep finding them, so when scene changes, it will find them again
             // TODO: make it so that it doesn't have to do this everytime
             // if I make them DontDestroyOnLoad, the network model moves, but the player themselves don't see the movement
-            XROrigin rig = FindObjectOfType<XROrigin>();
+            rig = FindObjectOfType<XROrigin>();
             if (rig != null)
             {
+                // make sure rig is same as gameObject's positiom (deals with wonky hand tracking before game starts)
+                rig.transform.position = gameObject.transform.position;
+
                 headRig = rig.transform.Find("Camera Offset/Main Camera");
                 leftHandRig = rig.transform.Find("Camera Offset/LeftHand Controller");
                 rightHandRig = rig.transform.Find("Camera Offset/RightHand Controller");
             }
-
             // currently commented out so only movement scripts affect position/rotation
             // can uncomment head.rotation part if we want others to see direction player is looking at, but it does look weird at times (e.g. 180 rotations twist neck)
             head.rotation = headRig.rotation;


### PR DESCRIPTION
Adjusted arm tracking so it is no longer wonky before game starts by making sure rig is always in the same position as the game object. However, now players will see that they fall and bounce when they spawn in (previously, rig position didn't update until after game start).