### PR TITLE
Many misc changes:

### DIFF
--- a/ExtremeRLGL/Assets/Resources/Player.prefab
+++ b/ExtremeRLGL/Assets/Resources/Player.prefab
@@ -1592,6 +1592,10 @@ MonoBehaviour:
   handRotThreshold: 12
   movingState: {fileID: 161061372}
   animator: {fileID: 4412153811984381101}
+  audioSource: {fileID: 0}
+  dingSound: {fileID: 8300000, guid: 8239e0e1189e1c748b5d7742903b8eaf, type: 3}
+  bzzSound: {fileID: 8300000, guid: 7edac91c70b562148ba0726904bf5c27, type: 3}
+  alreadyPlayingAudio: 0
 --- !u!114 &2439450006051917942
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/ExtremeRLGL/Assets/Scenes/MultiplayerGameScene.unity
+++ b/ExtremeRLGL/Assets/Scenes/MultiplayerGameScene.unity
@@ -2216,7 +2216,7 @@ AudioSource:
   m_PlayOnAwake: 0
   m_Volume: 0.5
   m_Pitch: 1
-  Loop: 1
+  Loop: 0
   Mute: 0
   Spatialize: 0
   SpatializePostEffects: 0

--- a/ExtremeRLGL/Assets/Scenes/MultiplayerGameScene.unity
+++ b/ExtremeRLGL/Assets/Scenes/MultiplayerGameScene.unity
@@ -270,6 +270,81 @@ MonoBehaviour:
   sceneViewId: 2
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!1 &52724075
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 52724076}
+  - component: {fileID: 52724078}
+  - component: {fileID: 52724077}
+  m_Layer: 9
+  m_Name: Warning Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &52724076
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 52724075}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1078196912}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -3.0000114, y: 51.43114}
+  m_SizeDelta: {x: 357.9, y: -50.13771}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &52724077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 52724075}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.25490198}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &52724078
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 52724075}
+  m_CullTransparentMesh: 1
 --- !u!1001 &57170537
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -421,7 +496,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &221998305
 RectTransform:
   m_ObjectHideFlags: 0
@@ -435,7 +510,7 @@ RectTransform:
   m_Children:
   - {fileID: 510039088}
   m_Father: {fileID: 1810527125}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1641,6 +1716,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 510039087}
   m_CullTransparentMesh: 1
+--- !u!1 &540126476
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 540126477}
+  - component: {fileID: 540126479}
+  - component: {fileID: 540126478}
+  m_Layer: 9
+  m_Name: Timer Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &540126477
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540126476}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1078196912}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -231.29999, y: 222.1}
+  m_SizeDelta: {x: 18.6, y: -43.800003}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &540126478
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540126476}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.25490198}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &540126479
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540126476}
+  m_CullTransparentMesh: 1
 --- !u!1 &549283871
 GameObject:
   m_ObjectHideFlags: 0
@@ -1926,12 +2076,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1078196912}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -3, y: 0}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchoredPosition: {x: -3.0000114, y: 56.562286}
+  m_SizeDelta: {x: 431.6, y: 21.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &675190752
 GameObject:
@@ -2873,7 +3023,7 @@ RectTransform:
   m_GameObject: {fileID: 962814932}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 2, y: 2, z: 2}
   m_Children: []
   m_Father: {fileID: 40057057}
   m_RootOrder: 2
@@ -2897,7 +3047,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3042,7 +3192,9 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 954637743}
+  - {fileID: 540126477}
   - {fileID: 1913121746}
+  - {fileID: 52724076}
   - {fileID: 652624661}
   - {fileID: 1626803942}
   m_Father: {fileID: 40057057}
@@ -4142,6 +4294,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: map
       objectReference: {fileID: 0}
+    - target: {fileID: 4037942552796177059, guid: ef0c2c38168a56d4498ba4d36b342743, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ef0c2c38168a56d4498ba4d36b342743, type: 3}
 --- !u!1 &1484722737
@@ -4471,7 +4627,7 @@ RectTransform:
   m_Children:
   - {fileID: 902977835}
   m_Father: {fileID: 1078196912}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6364,6 +6520,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1928071096650548279}
+  - {fileID: 1928071095175472799}
   - {fileID: 221998305}
   m_Father: {fileID: 1815794604}
   m_RootOrder: 0
@@ -6646,7 +6804,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1875079573}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2213c36610e3b1c4bbf886810ed9db12, type: 3}
   m_Name: 
@@ -6801,7 +6959,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 60 s
+  m_text: 180 s
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -6890,7 +7048,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1078196912}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7500,6 +7658,564 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2ab3a22ca8e988a46a0296f465d9fa91, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1928071094805526456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071094805526458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Leave
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1928071094805526457
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071094805526458}
+  m_CullTransparentMesh: 1
+--- !u!1 &1928071094805526458
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1928071094805526459}
+  - component: {fileID: 1928071094805526457}
+  - component: {fileID: 1928071094805526456}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1928071094805526459
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071094805526458}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1928071095175472799}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1928071095175472796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071095175472798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1928071095175472797}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1928071095175472798}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1810527126}
+        m_TargetAssemblyTypeName: RestartButton, Assembly-CSharp
+        m_MethodName: LeaveGame
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1928071095175472797
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071095175472798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.6132076, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1928071095175472798
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1928071095175472799}
+  - component: {fileID: 1928071095175472866}
+  - component: {fileID: 1928071095175472797}
+  - component: {fileID: 1928071095175472796}
+  m_Layer: 5
+  m_Name: Leave Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1928071095175472799
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071095175472798}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_Children:
+  - {fileID: 1928071094805526459}
+  m_Father: {fileID: 1810527125}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -37}
+  m_SizeDelta: {x: 79.225, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1928071095175472866
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071095175472798}
+  m_CullTransparentMesh: 1
+--- !u!114 &1928071095713099170
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071095713099356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Restart
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1928071095713099171
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071095713099356}
+  m_CullTransparentMesh: 1
+--- !u!1 &1928071095713099356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1928071095713099357}
+  - component: {fileID: 1928071095713099171}
+  - component: {fileID: 1928071095713099170}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1928071095713099357
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071095713099356}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1928071096650548279}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1928071096650548276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071096650548278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1928071096650548277}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1928071096650548278}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1810527126}
+        m_TargetAssemblyTypeName: RestartButton, Assembly-CSharp
+        m_MethodName: RestartGame
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1928071096650548277
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071096650548278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1928071096650548278
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1928071096650548279}
+  - component: {fileID: 1928071096650548282}
+  - component: {fileID: 1928071096650548277}
+  - component: {fileID: 1928071096650548276}
+  m_Layer: 5
+  m_Name: Restart Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1928071096650548279
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071096650548278}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_Children:
+  - {fileID: 1928071095713099357}
+  m_Father: {fileID: 1810527125}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -58}
+  m_SizeDelta: {x: 79.225, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1928071096650548282
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928071096650548278}
+  m_CullTransparentMesh: 1
 --- !u!1001 &2101555806755739045
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ExtremeRLGL/Assets/Scenes/MultiplayerLobbyScene.unity
+++ b/ExtremeRLGL/Assets/Scenes/MultiplayerLobbyScene.unity
@@ -1671,6 +1671,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   menu: {fileID: 1362469762}
   connectingText: {fileID: 1778308426}
+  canvas: {fileID: 705433525}
   quickUI: {fileID: 1720927281}
   roomUI: {fileID: 1735031940}
   createUI: {fileID: 1498103342}
@@ -6241,7 +6242,7 @@ Transform:
   m_GameObject: {fileID: 828197476}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4

--- a/ExtremeRLGL/Assets/Scripts/LightManager.cs
+++ b/ExtremeRLGL/Assets/Scripts/LightManager.cs
@@ -125,12 +125,14 @@ public class LightManager : MonoBehaviour, IPunObservable
             yield return new WaitForSeconds(1.0f);
             lightSound.Stop();
             yield return new WaitForSeconds(GetRandomTime(redLightTimeMean, redLightTimeStd));
+            dingSound.Play();
             
             for (int i = 0; i < redLightOn.Length; i++)
             {
                 redLightOn[i] = false;
             }
             Debug.Log("Turnning every light back to green");
+            
         }
     }
 

--- a/ExtremeRLGL/Assets/Scripts/LightManager.cs
+++ b/ExtremeRLGL/Assets/Scripts/LightManager.cs
@@ -119,11 +119,13 @@ public class LightManager : MonoBehaviour, IPunObservable
             redLightOn[2] = true;
             lightSound.Play();
             yield return new WaitForSeconds(1.0f);
-            lightSound.Stop();
+            lightSound.Pause();
             redLightOn[3] = true;
-            dingSound.Play();
+            lightSound.Play();
+            yield return new WaitForSeconds(1.0f);
+            lightSound.Stop();
             yield return new WaitForSeconds(GetRandomTime(redLightTimeMean, redLightTimeStd));
-            dingSound.Stop();
+            
             for (int i = 0; i < redLightOn.Length; i++)
             {
                 redLightOn[i] = false;

--- a/ExtremeRLGL/Assets/Scripts/MenuButtonReactor.cs
+++ b/ExtremeRLGL/Assets/Scripts/MenuButtonReactor.cs
@@ -21,7 +21,7 @@ public class MenuButtonReactor : MonoBehaviour
 
     public void onMenuButtonEvent(bool pressed)
     {
-        bool validGameStage = GameManager.gameStage == GameStage.Playing || GameManager.gameStage == GameStage.Countdown;
+        bool validGameStage = GameManager.gameStage == GameStage.Playing || GameManager.gameStage == GameStage.Countdown || GameManager.gameStage == GameStage.Ending;
         if (SceneManager.GetActiveScene().name == "MultiplayerGameScene" && validGameStage)
         {
             if (alreadyOpen && pressed)

--- a/ExtremeRLGL/Assets/Scripts/MiniMenuMovement.cs
+++ b/ExtremeRLGL/Assets/Scripts/MiniMenuMovement.cs
@@ -21,6 +21,8 @@ public class MiniMenuMovement : MonoBehaviour
         {
             // Move menu to player
             MenuButtonReactor.miniMenu.transform.position = gameObject.transform.position + new Vector3(0f, 1.4f, 2.4f);
+
+            GameObject.Find("Canvas").transform.position = gameObject.transform.position + new Vector3(0f, 1.4f, 2.4f);
         }
     }
 }

--- a/ExtremeRLGL/Assets/Scripts/MotionDetectionMultiplayer.cs
+++ b/ExtremeRLGL/Assets/Scripts/MotionDetectionMultiplayer.cs
@@ -183,12 +183,13 @@ public class MotionDetectionMultiplayer : MonoBehaviour
             {
                 //Debug.Log("Freeze");
                 // GetComponent<Renderer>().material.color = Color.red;
-                if (!alreadyPlayingAudio)
-                {
-                    audioSource.Stop();
-                    audioSource.PlayOneShot(dingSound);
-                    alreadyPlayingAudio = true;
-                }
+
+                //if (!alreadyPlayingAudio)
+                //{
+                //    audioSource.Stop();
+                //    audioSource.PlayOneShot(dingSound);
+                //    alreadyPlayingAudio = true;
+                //}
             }
         }
         else if (!LightManager.RedlightAllOn())

--- a/ExtremeRLGL/Assets/Scripts/MotionDetectionMultiplayer.cs
+++ b/ExtremeRLGL/Assets/Scripts/MotionDetectionMultiplayer.cs
@@ -58,6 +58,12 @@ public class MotionDetectionMultiplayer : MonoBehaviour
     // Animator
     public Animator animator;
 
+    // Audio
+    public AudioSource audioSource;
+    public AudioClip dingSound;
+    public AudioClip bzzSound;
+    public bool alreadyPlayingAudio;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -74,6 +80,8 @@ public class MotionDetectionMultiplayer : MonoBehaviour
             movingState.text = "";
         triggered = false;
         resetPosition = false;
+
+        audioSource = GameObject.Find("Main Camera").GetComponent<AudioSource>();
     }
 
     public void OnEnable()
@@ -108,6 +116,8 @@ public class MotionDetectionMultiplayer : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        audioSource = GameObject.Find("UI Camera").GetComponent<AudioSource>();
+
         if (startLine == null)
         {
             startLine = GameObject.FindGameObjectWithTag("StartLine").GetComponent<Collider>();
@@ -160,7 +170,12 @@ public class MotionDetectionMultiplayer : MonoBehaviour
                 cameraRotDist > cameraRotThreshold || leftRotDist > handRotThreshold || rightRotDist > handRotThreshold)
             {
                 if (!triggered && !playerPowerup.isActivate(PowerUpType.UNSTOPPABLE))
+                {
+                    audioSource.Stop();
+                    audioSource.PlayOneShot(bzzSound);
+                    alreadyPlayingAudio = true;
                     OnMoved();
+                }
             }
 
             // Executes if calculated distances are less than their respective thresholds
@@ -168,11 +183,18 @@ public class MotionDetectionMultiplayer : MonoBehaviour
             {
                 //Debug.Log("Freeze");
                 // GetComponent<Renderer>().material.color = Color.red;
+                if (!alreadyPlayingAudio)
+                {
+                    audioSource.Stop();
+                    audioSource.PlayOneShot(dingSound);
+                    alreadyPlayingAudio = true;
+                }
             }
         }
         else if (!LightManager.RedlightAllOn())
         {
             resetPosition = false;
+            alreadyPlayingAudio = false;
         }
     }
 

--- a/ExtremeRLGL/Assets/Scripts/NetworkPlayer.cs
+++ b/ExtremeRLGL/Assets/Scripts/NetworkPlayer.cs
@@ -71,7 +71,7 @@ public class NetworkPlayer : MonoBehaviour
             if (rig != null)
             {
                 // make sure rig is same as gameObject's positiom (deals with wonky hand tracking before game starts)
-                rig.transform.position = gameObject.transform.position;
+                //rig.transform.position = gameObject.transform.position;
 
                 headRig = rig.transform.Find("Camera Offset/Main Camera");
                 leftHandRig = rig.transform.Find("Camera Offset/LeftHand Controller");

--- a/ExtremeRLGL/Assets/Scripts/RestartButton.cs
+++ b/ExtremeRLGL/Assets/Scripts/RestartButton.cs
@@ -6,20 +6,28 @@ using Photon.Pun;
 
 public class RestartButton : MonoBehaviour
 {
-    private GameObject button;
+    private GameObject restartButton;
+    private GameObject leaveButton;
 
     // Start is called before the first frame update
     void Start()
     {
-        button = gameObject.transform.GetChild(0).gameObject;
-        button.SetActive(false);
-        button.GetComponent<Button>().onClick.AddListener(RestartGame);
+        restartButton = gameObject.transform.GetChild(0).gameObject;
+        restartButton.SetActive(false);
+
+        leaveButton = gameObject.transform.GetChild(1).gameObject;
+        leaveButton.SetActive(false);
     }
 
-    private void RestartGame()
+    public void RestartGame()
     {
         Debug.Log("Restarting the game!");
         GameManager.gameManager.GameRestart();
+    }
+
+    public void LeaveGame()
+    {
+        PhotonNetwork.Disconnect();
     }
 
     // Update is called once per frame
@@ -27,11 +35,13 @@ public class RestartButton : MonoBehaviour
     {
         if (GameManager.gameStage == GameStage.Ending && PhotonNetwork.IsMasterClient)
         {
-            button.SetActive(true);
+            restartButton.SetActive(true);
+            // leaveButton.SetActive(true);
         }
         else 
         {
-            button.SetActive(false);
+            restartButton.SetActive(false);
+            leaveButton.SetActive(false);
         }
     }
 }

--- a/ExtremeRLGL/Assets/Sound Effects/buzzer.mp3
+++ b/ExtremeRLGL/Assets/Sound Effects/buzzer.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db48ae774a83caa85dbb19b38148d7cd1fbeecaa60473b9634c40ae772270533
+size 28212

--- a/ExtremeRLGL/Assets/Sound Effects/buzzer.mp3.meta
+++ b/ExtremeRLGL/Assets/Sound Effects/buzzer.mp3.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 7edac91c70b562148ba0726904bf5c27
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ExtremeRLGL/Assets/Sound Effects/lights.mp3
+++ b/ExtremeRLGL/Assets/Sound Effects/lights.mp3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c2d5a6b5bb0dea60c42ffb0ddf49a77697a49069ae962a267de0e75590f7335
-size 98363
+oid sha256:ab422bcf2e389019878b343de11e2319220fd6838d74b7ede38ae0b8a75224af
+size 28852

--- a/ExtremeRLGL/ProjectSettings/ProjectSettings.asset
+++ b/ExtremeRLGL/ProjectSettings/ProjectSettings.asset
@@ -416,6 +416,9 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: b4fa035041e84fe43b0e6a74ad49064f, type: 2}
   - {fileID: 0}
   - {fileID: -3350130006047776797, guid: fce3a3a0034a67c49a9378018f77e25d, type: 2}


### PR DESCRIPTION
- Disabled snap turn on right controller
- Made flash not raycast target (so mouse can press start button when testing). Also made it bigger.
- Updated sound - fourth light noise instead of ding. Also trimmed beginning of light audio clip (to start a bit earlier and also the first one sounded a bit off). Ding sound on successfully staying still, buzzer sound on moved.
- Adjusted restart button at end. Started to add a leave button (disabled for now because buggy).
- Updated MiniMenuMovement script to move canvas to player as well.
- Made lobby plane bigger (since canvas moves around); could deal with later by recentering player when loading new scene.